### PR TITLE
Fix incorrect access control logic

### DIFF
--- a/src/main/java/me/blueslime/pixelmotd/listener/bungeecord/events/abstracts/AbstractLoginListener.java
+++ b/src/main/java/me/blueslime/pixelmotd/listener/bungeecord/events/abstracts/AbstractLoginListener.java
@@ -63,7 +63,7 @@ public class AbstractLoginListener extends ConnectionListener<Plugin, LoginEvent
         ConfigurationHandler settings = getControl();
 
         if (hasWhitelist()) {
-            if (!checkPlayer(ListType.WHITELIST, "global", username) || !checkUUID(ListType.WHITELIST, "global", uuid)) {
+            if (!checkPlayer(ListType.WHITELIST, "global", username) && !checkUUID(ListType.WHITELIST, "global", uuid)) {
                 String reason = ListUtil.ListToString(settings.getStringList("kick-message.global-whitelist"));
 
                 event.setCancelReason(
@@ -83,7 +83,7 @@ public class AbstractLoginListener extends ConnectionListener<Plugin, LoginEvent
         }
 
         if (hasBlacklist()) {
-            if (!checkPlayer(ListType.BLACKLIST, "global", username) || !checkUUID(ListType.BLACKLIST, "global", uuid)) {
+            if (checkPlayer(ListType.BLACKLIST, "global", username) || checkUUID(ListType.BLACKLIST, "global", uuid)) {
                 String reason = ListUtil.ListToString(settings.getStringList("kick-message.global-blacklist"));
 
                 event.setCancelReason(

--- a/src/main/java/me/blueslime/pixelmotd/listener/bungeecord/events/abstracts/AbstractServerConnectListener.java
+++ b/src/main/java/me/blueslime/pixelmotd/listener/bungeecord/events/abstracts/AbstractServerConnectListener.java
@@ -59,7 +59,7 @@ public class AbstractServerConnectListener extends ConnectionListener<Plugin, Se
         String path = getPlace().toStringLowerCase() + "." + serverName;
 
         if (settings.getStatus("whitelist." + path + ".enabled", false)) {
-            if (!checkPlayer(ListType.WHITELIST, path, username) || !checkUUID(ListType.WHITELIST, path, uuid)) {
+            if (!checkPlayer(ListType.WHITELIST, path, username) && !checkUUID(ListType.WHITELIST, path, uuid)) {
                 String reason = ListUtil.ListToString(settings.getStringList("kick-message.whitelist"));
 
                 connection.sendMessage(
@@ -79,7 +79,7 @@ public class AbstractServerConnectListener extends ConnectionListener<Plugin, Se
         }
 
         if (settings.getStatus("blacklist." + path + ".enabled", false)) {
-            if (!checkPlayer(ListType.BLACKLIST, path, username) || !checkUUID(ListType.BLACKLIST, path, uuid)) {
+            if (checkPlayer(ListType.BLACKLIST, path, username) || checkUUID(ListType.BLACKLIST, path, uuid)) {
                 String reason = ListUtil.ListToString(settings.getStringList("kick-message.blacklist"));
 
                 connection.sendMessage(

--- a/src/main/java/me/blueslime/pixelmotd/listener/spigot/events/abstracts/AbstractLoginListener.java
+++ b/src/main/java/me/blueslime/pixelmotd/listener/spigot/events/abstracts/AbstractLoginListener.java
@@ -53,7 +53,7 @@ public abstract class AbstractLoginListener  extends ConnectionListener<JavaPlug
         ConfigurationHandler settings = getControl();
 
         if (hasWhitelist()) {
-            if (!checkPlayer(ListType.WHITELIST, "global", username) || !checkUUID(ListType.WHITELIST, "global", uuid)) {
+            if (!checkPlayer(ListType.WHITELIST, "global", username) && !checkUUID(ListType.WHITELIST, "global", uuid)) {
                 String reason = ListUtil.ListToString(settings.getStringList("kick-message.global-whitelist"));
 
                 event.disallow(
@@ -72,7 +72,7 @@ public abstract class AbstractLoginListener  extends ConnectionListener<JavaPlug
         }
 
         if (hasBlacklist()) {
-            if (!checkPlayer(ListType.BLACKLIST, "global", username) || !checkUUID(ListType.BLACKLIST, "global", uuid)) {
+            if (checkPlayer(ListType.BLACKLIST, "global", username) || checkUUID(ListType.BLACKLIST, "global", uuid)) {
                 String reason = ListUtil.ListToString(settings.getStringList("kick-message.global-blacklist"));
 
                 event.disallow(

--- a/src/main/java/me/blueslime/pixelmotd/listener/spigot/events/abstracts/AbstractTeleportListener.java
+++ b/src/main/java/me/blueslime/pixelmotd/listener/spigot/events/abstracts/AbstractTeleportListener.java
@@ -53,7 +53,7 @@ public abstract class AbstractTeleportListener extends ConnectionListener<JavaPl
         String path = getPlace().toStringLowerCase() + "." + target;
 
         if (settings.getStatus("whitelist." + path + ".enabled", false)) {
-            if (!checkPlayer(ListType.WHITELIST, path, username) || !checkUUID(ListType.WHITELIST, path, uuid)) {
+            if (!checkPlayer(ListType.WHITELIST, path, username) && !checkUUID(ListType.WHITELIST, path, uuid)) {
                 String reason = ListUtil.ListToString(settings.getStringList("kick-message.whitelist"));
 
                 connection.sendMessage(
@@ -73,7 +73,7 @@ public abstract class AbstractTeleportListener extends ConnectionListener<JavaPl
         }
 
         if (settings.getStatus("blacklist." + path + ".enabled", false)) {
-            if (!checkPlayer(ListType.BLACKLIST, path, username) || !checkUUID(ListType.BLACKLIST, path, uuid)) {
+            if (checkPlayer(ListType.BLACKLIST, path, username) || checkUUID(ListType.BLACKLIST, path, uuid)) {
                 String reason = ListUtil.ListToString(settings.getStringList("kick-message.blacklist"));
 
                 connection.sendMessage(

--- a/src/main/java/me/blueslime/pixelmotd/listener/velocity/events/abstracts/AbstractLoginListener.java
+++ b/src/main/java/me/blueslime/pixelmotd/listener/velocity/events/abstracts/AbstractLoginListener.java
@@ -72,7 +72,7 @@ public class AbstractLoginListener  extends ConnectionListener<ProxyServer, Logi
         ConfigurationHandler settings = getControl();
 
         if (hasWhitelist()) {
-            if (!checkPlayer(ListType.WHITELIST, "global", username) || !checkUUID(ListType.WHITELIST, "global", uuid)) {
+            if (!checkPlayer(ListType.WHITELIST, "global", username) && !checkUUID(ListType.WHITELIST, "global", uuid)) {
                 String reason = ListUtil.ListToString(settings.getStringList("kick-message.global-whitelist"));
 
                 event.setResult(
@@ -90,7 +90,7 @@ public class AbstractLoginListener  extends ConnectionListener<ProxyServer, Logi
         }
 
         if (hasBlacklist()) {
-            if (!checkPlayer(ListType.BLACKLIST, "global", username) || !checkUUID(ListType.BLACKLIST, "global", uuid)) {
+            if (checkPlayer(ListType.BLACKLIST, "global", username) || checkUUID(ListType.BLACKLIST, "global", uuid)) {
                 String reason = ListUtil.ListToString(settings.getStringList("kick-message.global-blacklist"));
 
                 event.setResult(

--- a/src/main/java/me/blueslime/pixelmotd/listener/velocity/events/abstracts/AbstractServerConnectListener.java
+++ b/src/main/java/me/blueslime/pixelmotd/listener/velocity/events/abstracts/AbstractServerConnectListener.java
@@ -80,7 +80,7 @@ public class AbstractServerConnectListener extends ConnectionListener<ProxyServe
         String path = getPlace().toStringLowerCase() + "." + serverName;
 
         if (settings.getStatus("whitelist." + path + ".enabled", false)) {
-            if (!checkPlayer(ListType.WHITELIST, path, username) || !checkUUID(ListType.WHITELIST, path, uuid)) {
+            if (!checkPlayer(ListType.WHITELIST, path, username) && !checkUUID(ListType.WHITELIST, path, uuid)) {
                 String reason = ListUtil.ListToString(settings.getStringList("kick-message.whitelist"));
 
                 connection.sendMessage(
@@ -102,7 +102,7 @@ public class AbstractServerConnectListener extends ConnectionListener<ProxyServe
         }
 
         if (settings.getStatus("blacklist." + path + ".enabled", false)) {
-            if (!checkPlayer(ListType.BLACKLIST, path, username) || !checkUUID(ListType.BLACKLIST, path, uuid)) {
+            if (checkPlayer(ListType.BLACKLIST, path, username) || checkUUID(ListType.BLACKLIST, path, uuid)) {
                 String reason = ListUtil.ListToString(settings.getStringList("kick-message.blacklist"));
 
                 connection.sendMessage(


### PR DESCRIPTION
This pull request patches the incorrect access control logic enforced in the connection/server switch listeners.

Currently, the code denies access "if player is not in username whitelist or if player is not in UUID whitelist", where the intent seems to be to deny access if the player is in neither of those lists.

Unfortunately, the same check is also applied to blacklisting, where the code denies access "if player is not in username blacklist or if player is not in UUID blacklist", where the intent seems to be to deny access if the player is in either of those lists.